### PR TITLE
removes sync web3.eth calls and checks the parent window for a web3 instance

### DIFF
--- a/imports/ethereum/ui/utils/web3.js
+++ b/imports/ethereum/ui/utils/web3.js
@@ -6,6 +6,8 @@ window.addEventListener('load', function() {
   if (window.web3) {
     web3.setProvider(window.web3.currentProvider);
     delete window.web3;
+  } else if (window.parent !== window && window.parent.web3 !== undefined) {
+    web3.setProvider(window.parent.web3.currentProvider);
   }
 });
 

--- a/imports/voting/ui/particles/SignStatement.vue
+++ b/imports/voting/ui/particles/SignStatement.vue
@@ -58,9 +58,15 @@
     data() {
       return {
         signature: '',
-        canSignByWeb3: !!(web3.currentProvider && web3.eth.accounts[0]),
+        canSignByWeb3: false,
         upVote: this.desiredVote,
       }
+    },
+    mounted() {
+      web3.eth.getAccounts((err, accounts) => {
+        if (err) return;
+        else this.canSignByWeb3 = accounts.length > 0
+      });
     },
     methods: {
       setUpVote(upVote) {
@@ -68,10 +74,17 @@
         if (this.canSignByWeb3) {
           const statement = this.statement;
           if (!statement) return;
-          const { eth: { accounts }, personal: { sign }, toHex } = web3;
-          sign(toHex(this.messageToSign), accounts[0], (error, signature) => {
-            if (error) this.$store.dispatch('handleError', { error, upVote });
-            else this.signatureHandler({ statement, signature, upVote });
+          web3.eth.getAccounts((err, accounts) => {
+            if (err) {
+              this.$store.dispatch('handleError', { error, upVote });
+              return;
+            }
+            const { personal: { sign }, toHex } = web3;
+
+            sign(toHex(this.messageToSign), accounts[0], (error, signature) => {
+              if (error) this.$store.dispatch('handleError', { error, upVote });
+              else this.signatureHandler({ statement, signature, upVote });
+            });
           });
         }
       },


### PR DESCRIPTION
These changes allow the voting app to be used with the identity provider.