### PR TITLE
Encode messages to utf8 before signing

### DIFF
--- a/imports/ethereum/api/utils/genAdminLoginStatement.js
+++ b/imports/ethereum/api/utils/genAdminLoginStatement.js
@@ -1,2 +1,2 @@
 export default () =>
-  `I want to login the Aeternity Voting as admin on ${(new Date()).toISOString()}`;
+  `I want to login the Æternity Voting as admin on ${(new Date()).toISOString()}`;

--- a/imports/ethereum/api/utils/server/signature.tests.js
+++ b/imports/ethereum/api/utils/server/signature.tests.js
@@ -1,0 +1,27 @@
+import { describe, it } from 'meteor/practicalmeteor:mocha';
+import { expect } from 'meteor/practicalmeteor:chai';
+
+import { getEthereumAddress } from '../signature';
+
+describe('getEthereumAddress', () => {
+  const address = '0xfa491df8780761853d127a9f7b2772d688a0e3b5';
+  const message = (upVote, statement) => `I ${upVote ? '' : 'dis'}agree that ${statement}`;
+
+  it('correct process signatures', () => {
+    const statement = 'test';
+    const upVoteSignature = '0xede222564b846a123ed16446fc0bb9e59e8c3df98ac4883870c1ec5ab3220e6a3d98b4cbbbf4009145260966d8944d0514cf2425e2124e6fd5ebdfc3bb777dd01b';
+    const downVoteSignature = '0x60c105f35e9e7acf17c1da2b1f87882c137736eaf79909e125c954265c0c58165c972e8151371504e130d7114c95ccb7abeba956e6d695d17f8b544a1843b37c1b';
+
+    expect(getEthereumAddress(message(true, statement), upVoteSignature)).to.equal(address);
+    expect(getEthereumAddress(message(false, statement), downVoteSignature)).to.equal(address);
+  });
+
+  it('correct process signatures with non-ASCII chars', () => {
+    const statement = 'тест';
+    const upVoteSignature = '0xfe81406e7dc7de1b0b9c1857fdb7b18209bba9c45b329c5b6cca4cf67c73d9c801fbb08453bb7ce85f7c4ea1340962adfd544c7757feafa5ba269291ce18a7261b';
+    const downVoteSignature = '0x59baa2616675b31ab207d4aa2005d0b14262b505fa2701340000d59abf3384533094457851f7e9175ad2c5c0765a8a6b0254fae4964fdb274a2781089fe540281c';
+
+    expect(getEthereumAddress(message(true, statement), upVoteSignature)).to.equal(address);
+    expect(getEthereumAddress(message(false, statement), downVoteSignature)).to.equal(address);
+  });
+});

--- a/imports/ethereum/api/utils/signature.js
+++ b/imports/ethereum/api/utils/signature.js
@@ -1,4 +1,5 @@
 import ethereumjs from 'ethereumjs-util';
+import utf8 from 'utf8';
 
 export const getEthereumAddress = (message, signature) => {
   const { sha3, ecrecover, pubToAddress } = ethereumjs;
@@ -6,7 +7,7 @@ export const getEthereumAddress = (message, signature) => {
   const r = new Buffer(signature.slice(2, 64 + 2), 'hex');
   const s = new Buffer(signature.slice(64 + 2, 128 + 2), 'hex');
   const v = parseInt(signature.slice(128 + 2), 16);
-  const messageHash = sha3(`\x19Ethereum Signed Message:\n${message.length}${message}`);
+  const messageHash = sha3(`\x19Ethereum Signed Message:\n${utf8.encode(message).length}${message}`);
   const publicKey = ecrecover(messageHash, v, r, s);
   return `0x${pubToAddress(publicKey).toString('hex')}`;
 };

--- a/imports/voting/api/store/voting.js
+++ b/imports/voting/api/store/voting.js
@@ -1,4 +1,5 @@
 import { Accounts } from 'meteor/accounts-base';
+import utf8 from 'utf8';
 
 import web3 from '/imports/ethereum/ui/utils/web3';
 import getAdminLoginStatement from '/imports/ethereum/api/utils/genAdminLoginStatement';
@@ -51,7 +52,7 @@ export default {
       } else {
         const { personal: { sign }, toHex } = web3;
         const message = getAdminLoginStatement();
-        sign(toHex(message), state.accountId, (error, signature) => {
+        sign(toHex(utf8.encode(message)), state.accountId, (error, signature) => {
           if (error) throw error;
           else Accounts.callLoginMethod({
             methodArguments: [{ message, signature }],

--- a/imports/voting/ui/particles/SignStatement.vue
+++ b/imports/voting/ui/particles/SignStatement.vue
@@ -47,6 +47,7 @@
 
 <script>
   import { mapState, mapMutations } from 'vuex';
+  import utf8 from 'utf8';
 
   import { Accounts } from '/imports/accounts';
   import web3 from '/imports/ethereum/ui/utils/web3';
@@ -74,7 +75,7 @@
           const statement = this.statement;
           if (!statement) return;
           const { personal: { sign }, toHex } = web3;
-          sign(toHex(this.messageToSign), this.accountId, (error, signature) => {
+          sign(toHex(utf8.encode(this.messageToSign)), this.accountId, (error, signature) => {
             if (error) this.$store.dispatch('handleError', { error, upVote });
             else this.signatureHandler({ statement, signature, upVote });
           });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment": "^2.18.1",
     "simpl-schema": "^0.3.2",
     "underscore": "^1.8.3",
+    "utf8": "^2.1.2",
     "vue": "^2.4.2",
     "vue-autosize": "^1.0.2",
     "vue-clipboards": "^1.1.0",


### PR DESCRIPTION
For proper signing messages with non-ASCII chars. Signatures in tests generated by https://www.myetherwallet.com/signmsg.html.
This is not compatible with already made votes for statements with non-ASCII chars.